### PR TITLE
Fix for Notice: Undefined index: enqueue

### DIFF
--- a/wp-scss.php
+++ b/wp-scss.php
@@ -132,7 +132,7 @@ $wpscss_settings = array(
   'css_dir'   =>  WPSCSS_THEME_DIR . $css_dir_setting,
   'compiling' =>  $wpscss_options['compiling_options'], 
   'errors'    =>  $wpscss_options['errors'],
-  'enqueue'   =>  $wpscss_options['enqueue']
+  'enqueue'   =>  isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
 );
 
 


### PR DESCRIPTION
When option Enqueue Stylesheets is unchecked
