### PR TITLE
Update .gitignore

### DIFF
--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,1 +1,3 @@
 *
+
+!.gitignore


### PR DESCRIPTION
Make git ignore all files in /cache/ except the .gitignore file itself.  This forces git to add the /cache/ folder when committing the plugin preventing the "File Permission Error, permission denied. Please make the cache directory writable." error from occurring due to a missing folder.
