### PR TITLE
Fixed error message when compiling

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -71,7 +71,7 @@ class Wp_Scss {
           }
         } else {
           $errors = array (
-            'file' => "/wp-plugins/wp-scss/cache/",
+            'file' => $cache,
             'message' => "File Permission Error, permission denied. Please make the cache directory writable."
           );
           array_push($instance->compile_errors, $errors);


### PR DESCRIPTION
When compiling failed, the resulting error message referred to
an obsolete pathname, hardcoding it. Now it displays the correct
path to the cache folder.

Attempts to fix https://github.com/ConnectThink/WP-SCSS/issues/22
