### PR TITLE
Added need compiling configuration constant.

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -133,6 +133,10 @@ class Wp_Scss {
    * @return bool - true if compiling is needed
    */
     public function needs_compiling() {
+      if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE) {
+        return true;
+      }
+
       $latest_scss = 0;
       $latest_css = 0;
 


### PR DESCRIPTION
During development it's sometimes useful to force stylesheet compilation on every page load. Especially on cheap dollar hosts where I've experienced issues with the stat cache resulting in `filemtime()` not updating consistently.

Adding `define('WP_SCSS_ALWAYS_RECOMPILE', true);` to your `wp-config.php` file will cause stylesheets to be recompiled on every page load. 