### PR TITLE
Add option to minify CSS output

### DIFF
--- a/options.php
+++ b/options.php
@@ -208,7 +208,8 @@ class Wp_Scss_Settings
         $html = '<select id="compiling_options" name="wpscss_options[compiling_options]">';  
             $html .= '<option value="scss_formatter"' . selected( $this->options['compiling_options'], 'scss_formatter', false) . '>Expanded</option>';  
             $html .= '<option value="scss_formatter_nested"' . selected( $this->options['compiling_options'], 'scss_formatter_nested', false) . '>Nested</option>';  
-            $html .= '<option value="scss_formatter_compressed"' . selected( $this->options['compiling_options'], 'scss_formatter_compressed', false) . '>Compressed</option>';  
+            $html .= '<option value="scss_formatter_compressed"' . selected( $this->options['compiling_options'], 'scss_formatter_compressed', false) . '>Compressed</option>'; 
+            $html .= '<option value="scss_formatter_minified"' . selected( $this->options['compiling_options'], 'scss_formatter_minified', false) . '>Minified (No Comments)</option>';   
         $html .= '</select>';  
       
     echo $html;  

--- a/scssphp/scss.inc.php
+++ b/scssphp/scss.inc.php
@@ -4339,6 +4339,32 @@ class scss_formatter_compressed extends scss_formatter {
 }
 
 /**
+ * SCSS minified formatter
+ *
+ * @author Mike DeWitt
+ */
+class scss_formatter_minified extends scss_formatter {
+	public $open = "{";
+	public $tagSeparator = ",";
+	public $assignSeparator = ":";
+	public $break = "";
+
+	public function indentStr($n = 0) {
+		return "";
+	}
+
+	public function format($block) {
+		ob_start();
+		$this->block($block);
+		$out = ob_get_clean();
+
+		$out = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $out);
+
+		return $out;
+	}
+}
+
+/**
  * SCSS server
  *
  * @author Leaf Corcoran <leafot@gmail.com>


### PR DESCRIPTION
Hi guys,

Love the plugin.  I added a quick feature to minify the CSS output.  I was using your plugin in conjunction with the Bones theme framework, which has a ton of comments spread across a ton of files.  This added a lot of unnecessary bulk to the output.  I thought others might appreciate this option...
