### PR TITLE
Add feature to enable file path line comments

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -21,7 +21,7 @@ class Wp_Scss {
    *
    * @var array compile_errors - catches errors from compile
    */
-  public function __construct ($scss_dir, $css_dir, $compile_method) {
+  public function __construct ($scss_dir, $css_dir, $compile_method, $print_numbers) {
     $this->scss_dir = $scss_dir;
     $this->css_dir = $css_dir;
     $this->compile_method = $compile_method;
@@ -30,6 +30,9 @@ class Wp_Scss {
     $scssc = new scssc();
     $scssc->setFormatter($compile_method);
     $scssc->setImportPaths($scss_dir);
+
+    echo '<pre>print_numbers: '.print_r($print_numbers, true).'</pre>';
+    $scssc->setLineNumbers($print_numbers);
 
     $this->compile_errors = array();
   }

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -30,8 +30,6 @@ class Wp_Scss {
     $scssc = new scssc();
     $scssc->setFormatter($compile_method);
     $scssc->setImportPaths($scss_dir);
-
-    echo '<pre>print_numbers: '.print_r($print_numbers, true).'</pre>';
     $scssc->setLineNumbers($print_numbers);
 
     $this->compile_errors = array();

--- a/options.php
+++ b/options.php
@@ -22,10 +22,10 @@ class Wp_Scss_Settings
     {
         // This page will be under "Settings"
         add_options_page(
-            'Settings Admin', 
-            'WP-SCSS', 
-            'manage_options', 
-            'wpscss_options', 
+            'Settings Admin',
+            'WP-SCSS',
+            'manage_options',
+            'wpscss_options',
             array( $this, 'create_admin_page' )
         );
     }
@@ -40,20 +40,20 @@ class Wp_Scss_Settings
         ?>
         <div class="wrap">
             <?php screen_icon(); ?>
-            <h2>WP-SCSS Settings</h2>   
+            <h2>WP-SCSS Settings</h2>
             <p>
               <span class="version">Version <em><?php echo get_option('wpscss_version'); ?></em>
               <br/>
               <span class="author">By: <a href="http://connectthink.com" target="_blank">Connect Think</a></span>
               <br/>
-              <span class="repo">Help & Issues: <a href="https://github.com/ConnectThink/WP-SCSS" target="_blank">Github</a></span>
-            </p>        
+              <span class="repo">Help &amp; Issues: <a href="https://github.com/ConnectThink/WP-SCSS" target="_blank">Github</a></span>
+            </p>
             <form method="post" action="options.php">
             <?php
                 // This prints out all hidden setting fields
-                settings_fields( 'wpscss_options_group' );   
+                settings_fields( 'wpscss_options_group' );
                 do_settings_sections( 'wpscss_options' );
-                submit_button(); 
+                submit_button();
             ?>
             </form>
         </div>
@@ -64,7 +64,7 @@ class Wp_Scss_Settings
      * Register and add settings
      */
     public function page_init()
-    {        
+    {
         register_setting(
             'wpscss_options_group', // Option group
             'wpscss_options', // Option name
@@ -77,19 +77,19 @@ class Wp_Scss_Settings
             'Configure Paths', // Title
             array( $this, 'print_paths_info' ), // Callback
             'wpscss_options' // Page
-        );  
+        );
         add_settings_field(
             'wpscss_scss_dir', // ID
-            'Scss Location', // Title 
+            'Scss Location', // Title
             array( $this, 'scss_dir_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_paths_section' // Section           
-        );      
+            'wpscss_paths_section' // Section
+        );
         add_settings_field(
-            'wpscss_css_dir', 
-            'CSS Location', 
-            array( $this, 'css_dir_callback' ), 
-            'wpscss_options', 
+            'wpscss_css_dir',
+            'CSS Location',
+            array( $this, 'css_dir_callback' ),
+            'wpscss_options',
             'wpscss_paths_section'
         );
 
@@ -99,21 +99,28 @@ class Wp_Scss_Settings
             'Compiling Options', // Title
             array( $this, 'print_compile_info' ), // Callback
             'wpscss_options' // Page
-        );  
+        );
         add_settings_field(
-            'Compiling Mode', 
-            'Compiling Mode', 
+            'Compiling Mode',
+            'Compiling Mode',
             array( $this, 'compiling_mode_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_compile_section' // Section           
-        );      
+            'wpscss_compile_section' // Section
+        );
         add_settings_field(
-            'Error Display', 
-            'Error Display', 
+            'Error Display',
+            'Error Display',
             array( $this, 'errors_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_compile_section' // Section   
-        );            
+            'wpscss_compile_section' // Section
+        );
+        add_settings_field(
+            'Print Line Numbers',
+            'Print Line Numbers',
+            array( $this, 'printnumbers_callback' ), // Callback
+            'wpscss_options', // Page
+            'wpscss_compile_section' // Section
+        );
 
         // Compiling Options
         add_settings_section(
@@ -121,21 +128,21 @@ class Wp_Scss_Settings
             'Compiling Options', // Title
             array( $this, 'print_compile_info' ), // Callback
             'wpscss_options' // Page
-        );  
+        );
         add_settings_field(
-            'Compiling Mode', 
-            'Compiling Mode', 
+            'Compiling Mode',
+            'Compiling Mode',
             array( $this, 'compiling_mode_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_compile_section' // Section           
-        );      
+            'wpscss_compile_section' // Section
+        );
         add_settings_field(
-            'Error Display', 
-            'Error Display', 
+            'Error Display',
+            'Error Display',
             array( $this, 'errors_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_compile_section' // Section   
-        );            
+            'wpscss_compile_section' // Section
+        );
 
         // Enqueuing Options
         add_settings_section(
@@ -143,15 +150,15 @@ class Wp_Scss_Settings
             'Enqueuing Options', // Title
             array( $this, 'print_enqueue_info' ), // Callback
             'wpscss_options' // Page
-        );  
+        );
         add_settings_field(
-            'Enqueue Stylesheets', 
-            'Enqueue Stylesheets', 
+            'Enqueue Stylesheets',
+            'Enqueue Stylesheets',
             array( $this, 'enqueue_callback' ), // Callback
             'wpscss_options', // Page
-            'wpscss_enqueue_section' // Section           
-        );      
-                   
+            'wpscss_enqueue_section' // Section
+        );
+
     }
 
     /**
@@ -170,7 +177,7 @@ class Wp_Scss_Settings
         return $input;
     }
 
-    /** 
+    /**
      * Print the Section text
      */
     public function print_paths_info() {
@@ -183,7 +190,7 @@ class Wp_Scss_Settings
         print 'WP-SCSS can enqueue your css stylesheets in the header automatically.';
     }
 
-    /** 
+    /**
      * Text Fields' Callbacks
      */
     public function scss_dir_callback() {
@@ -199,43 +206,51 @@ class Wp_Scss_Settings
         );
     }
 
-    /** 
+    /**
      * Select Boxes' Callbacks
      */
     public function compiling_mode_callback() {
-        $this->options = get_option( 'wpscss_options' );  
-        
-        $html = '<select id="compiling_options" name="wpscss_options[compiling_options]">';  
-            $html .= '<option value="scss_formatter"' . selected( $this->options['compiling_options'], 'scss_formatter', false) . '>Expanded</option>';  
-            $html .= '<option value="scss_formatter_nested"' . selected( $this->options['compiling_options'], 'scss_formatter_nested', false) . '>Nested</option>';  
-            $html .= '<option value="scss_formatter_compressed"' . selected( $this->options['compiling_options'], 'scss_formatter_compressed', false) . '>Compressed</option>';  
-        $html .= '</select>';  
-      
-    echo $html;  
+        $this->options = get_option( 'wpscss_options' );
+
+        $html = '<select id="compiling_options" name="wpscss_options[compiling_options]">';
+            $html .= '<option value="scss_formatter"' . selected( $this->options['compiling_options'], 'scss_formatter', false) . '>Expanded</option>';
+            $html .= '<option value="scss_formatter_nested"' . selected( $this->options['compiling_options'], 'scss_formatter_nested', false) . '>Nested</option>';
+            $html .= '<option value="scss_formatter_compressed"' . selected( $this->options['compiling_options'], 'scss_formatter_compressed', false) . '>Compressed</option>';
+        $html .= '</select>';
+
+    echo $html;
     }
     public function errors_callback() {
-        $this->options = get_option( 'wpscss_options' );  
-        
-        $html = '<select id="errors" name="wpscss_options[errors]">';  
-            $html .= '<option value="show"' . selected( $this->options['errors'], 'show', false) . '>Show in Header</option>';  
+        $this->options = get_option( 'wpscss_options' );
+
+        $html = '<select id="errors" name="wpscss_options[errors]">';
+            $html .= '<option value="show"' . selected( $this->options['errors'], 'show', false) . '>Show in Header</option>';
             $html .= '<option value="show-logged-in"' . selected( $this->options['errors'], 'show-logged-in', false) . '>Show to Logged In Users</option>';
-            $html .= '<option value="log"' . selected( $this->options['errors'], 'hide', false) . '>Print to Log</option>';  
-        $html .= '</select>';  
-      
-    echo $html;  
+            $html .= '<option value="log"' . selected( $this->options['errors'], 'hide', false) . '>Print to Log</option>';
+        $html .= '</select>';
+
+    echo $html;
     }
 
-    /** 
+    /**
      * Checkboxes' Callbacks
      */
-    function enqueue_callback() {  
-      $this->options = get_option( 'wpscss_options' );  
-        
-      $html = '<input type="checkbox" id="enqueue" name="wpscss_options[enqueue]" value="1"' . checked( 1, isset($this->options['enqueue']) ? $this->options['enqueue'] : 0, false ) . '/>';   
-      $html .= '<label for="enqueue"></label>';  
-      
-    echo $html;  
-    } 
+    function enqueue_callback() {
+      $this->options = get_option( 'wpscss_options' );
+
+      $html = '<input type="checkbox" id="enqueue" name="wpscss_options[enqueue]" value="1"' . checked( 1, isset($this->options['enqueue']) ? $this->options['enqueue'] : 0, false ) . '/>';
+      $html .= '<label for="enqueue"></label>';
+
+    echo $html;
+    }
+    function printnumbers_callback() {
+      $this->options = get_option( 'wpscss_options' );
+
+      $html = '<input type="checkbox" id="printnumbers" name="wpscss_options[printnumbers]" value="1"' . checked( 1, isset($this->options['printnumbers']) ? $this->options['printnumbers'] : 0, false ) . '/>';
+      $html .= '<label for="printnumbers">Add line number comments to stylesheet output</label>';
+
+    echo $html;
+    }
 
 }
 

--- a/scssphp/scss.inc.php
+++ b/scssphp/scss.inc.php
@@ -2493,6 +2493,41 @@ class scssc {
 
 		throw new Exception($msg);
 	}
+	/*
+	 * check if line number feature is active
+	 * @return boolean
+	 */
+	public function isLineNumbers()	{
+		return $this->lineNumbers;
+	}
+
+	/**
+	 * use this function to turn line numbers on
+	 * @param boolean $lineNumbers
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function setLineNumbers($lineNumbers, $filename = NULL) {
+		$this->lineNumbers = $lineNumbers;
+
+		if ($filename) {
+			$this->setFileName($filename);
+		}
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFileName()	{
+		return $this->fileName;
+	}
+
+	/**
+	 * @param string $fileName
+	 */
+	public function setFileName($fileName) {
+		$this->fileName = $fileName;
+	}
 
 	/**
 	 * CSS Colors
@@ -4571,4 +4606,245 @@ class scss_server {
 		$server = new self($path);
 		$server->serve();
 	}
+}
+
+/**
+ * SCSS line commentator
+ *
+ * @author Gerhard Boden
+ * @integration Eric McNiece <emcniece@gmail.com>
+ */
+class scss_linecommentator{
+
+	const comment_indicator_start = '/*';
+	const comment_indicator_end = '*/';
+
+	const block_indicator_start = '{';
+	const block_indicator_end = '}';
+
+	const html_comment_indicator_start = '<!--';
+	const html_comment_indicator_end = '-->';
+
+	const function_indicator = '@function';
+	const return_indicator = '@return';
+
+	const mixin_indicator = '@mixin';
+
+	const include_indicator = '@include';
+
+	const if_statement_indicator = '@if';
+	const else_statement_indicator = '@else';
+
+	const loop_indicator_for = "@for";
+	const loop_indicator_while = "@while";
+	const loop_indicator_each = "@each";
+
+	//we use this to indicate that we are currently looping within a multiline comment
+	static protected $inside_multiline;
+
+
+	/* insert line number as commentary within the SCSS file
+	 *
+	 * @return string;
+	 */
+
+
+	static function insertLineComments($scss, $filepath = '')
+	{
+
+		$lines = $scss;
+		$new_scss_content = array();
+
+		$filepath = str_replace('\\', '/', $filepath);
+
+		foreach ($lines as $linenumber => $line) {
+
+			$line = trim($line);
+			$nextline = trim(next($lines));
+
+			//check if empty
+			if (empty($line)) {
+				continue;
+			}
+
+			//check if line is a commment
+			if (self::isComment($line) || self::$inside_multiline) {
+				$new_scss_content[] = $line;
+				continue;
+			}
+
+			//write line numbers for selectors only to reduce overhead
+			if (
+				self::isSelector($line, $nextline) == FALSE ||
+				self::isFunction($line) == TRUE ||
+				self::isMixin($line) == TRUE ||
+				self::isInclude($line) == TRUE ||
+				self::isCondition($line) == TRUE ||
+				self::isLoop($line) == TRUE
+			) {
+				$new_scss_content[] = $line;
+				continue;
+			}
+
+
+			//output line commment
+			$new_scss_content[] = self::comment_indicator_start . ' line ' . ($linenumber + 1) . ', ' . $filepath . ' ' . self::comment_indicator_end;
+
+			$new_scss_content[] = $line;
+
+		}
+
+
+		return implode("\n", $new_scss_content);
+	}
+
+	/*
+	 * looking for selector block:
+	 * the opening  bracket could be in the same line or in the next one (since we've cleaned empty lines)
+	 * also we don't want to confuse a selector block with a property block or write the comment above the bracket
+	 * itself (in case it's in a new line)
+	 *
+	 * @return boolean
+	 */
+	static function isSelector($line, $nextline = NULL)
+	{
+
+		if (
+			(strpos($line, self::block_indicator_start) !== FALSE || strpos($nextline, self::block_indicator_start) === 0)
+			&& strpos($line, self::block_indicator_start) !== 0
+		) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/*
+	 * ignore mixins. mixins will spread inside selectors after compilation
+	 *
+	 * @return: boolean
+	 */
+
+	static function isMixin($line)
+	{
+		if (strpos($line, self::mixin_indicator) !== FALSE) {
+			return true;
+		}
+
+		return false;
+	}
+
+
+	/*
+	 * ignore functions
+	 *
+	 * @return: boolean
+	 */
+
+	static function isFunction($line)
+	{
+
+		if
+		(
+			strpos($line, self::function_indicator) !== FALSE ||
+			strpos($line, self::return_indicator) !== FALSE
+		) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+
+	/*
+	 * ignore include
+	 *
+	 * @return: boolean
+	 */
+
+	static function isInclude($line)
+	{
+
+		if (strpos($line, self::include_indicator) !== FALSE) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/*
+	 * dont't put a line number above if statement, since it will result in an empty line within the
+	 * compiled scss
+	 */
+	static function isCondition($line) {
+		if
+		(
+			strpos($line, self::if_statement_indicator) !== FALSE ||
+			strpos($line, self::else_statement_indicator) !== FALSE
+		) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/*
+	* dont't put a line number above loops, since it will result in an empty line within the
+	* compiled scss
+	 */
+	static function isLoop($line) {
+
+		if
+		(
+			strpos($line, self::loop_indicator_for) !== FALSE ||
+			strpos($line, self::loop_indicator_each) !== FALSE ||
+			strpos($line, self::loop_indicator_while) !== FALSE
+		) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+
+	/*
+	 * we don't want to mess around with existing comments since this can easily lead to parsing errors.
+	 *
+	 * @return boolean
+	 */
+
+	static function isComment($line)
+	{
+
+		/* a comment has started, but did not end in the same line */
+		if (strpos($line, self::comment_indicator_start) !== FALSE && strpos($line, self::comment_indicator_end) === FALSE) {
+			self::$inside_multiline = TRUE;
+			return true;
+
+			/* check for comment to end */
+		} else if (strpos($line, self::comment_indicator_end) !== FALSE) {
+			self::$inside_multiline = FALSE;
+			return true;
+		}
+
+		/*same check for html comments within scss.. just in case someone is having a bad day
+		  scssphp will remove this tags later on, but still has a problem with it if we wrap an CSS commentary around it*/
+
+		if (strpos($line, self::html_comment_indicator_start) !== FALSE && strpos($line, self::html_comment_indicator_end) === FALSE) {
+			self::$inside_multiline = TRUE;
+			return true;
+
+		} else if (strpos($line, self::comment_indicator_end) !== FALSE) {
+			self::$inside_multiline = FALSE;
+			return true;
+		}
+
+		return false;
+	}
+
 }

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -128,11 +128,12 @@ if( $scss_dir_setting == false || $css_dir_setting == false ) {
 
 // Plugin Settings
 $wpscss_settings = array(
-  'scss_dir'  =>  WPSCSS_THEME_DIR . $scss_dir_setting,
-  'css_dir'   =>  WPSCSS_THEME_DIR . $css_dir_setting,
-  'compiling' =>  $wpscss_options['compiling_options'],
-  'errors'    =>  $wpscss_options['errors'],
-  'enqueue'   =>  isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
+  'scss_dir'     =>  WPSCSS_THEME_DIR . $scss_dir_setting,
+  'css_dir'      =>  WPSCSS_THEME_DIR . $css_dir_setting,
+  'compiling'    =>  $wpscss_options['compiling_options'],
+  'errors'       =>  $wpscss_options['errors'],
+  'printnumbers' =>  $wpscss_options['printnumbers'],
+  'enqueue'      =>  isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
 );
 
 
@@ -146,7 +147,8 @@ $wpscss_settings = array(
 $wpscss_compiler = new Wp_Scss(
   $wpscss_settings['scss_dir'],
   $wpscss_settings['css_dir'],
-  $wpscss_settings['compiling']
+  $wpscss_settings['compiling'],
+  $wpscss_settings['printnumbers']
 );
 
 


### PR DESCRIPTION
https://github.com/gerhard-boden/scssphp is a branch of https://github.com/leafo/scssphp that enables an option to add line numbers to the compiled CSS file. Though not officially merged into master, this is a very helpful feature. Since WP-SCSS does not use scssphp as a direct submodule, it may be worth considering integrating.

This PR adds a checkbox option at `wp-admin/options-general.php?page=wpscss_options` to enable line comments. Enable the checkbox, edit SCSS file, then refresh a browser page to see the resulting output.

The block at `@@ -688,7 +699,16 @@ protected function compileChild($child, $out) {` may need review. With this new feature, line number comments were being added for every regular comment line resulting in large sections of line number comments with no content. I didn't quite have enough time to test this more thoroughly, and the root-level-only (non-nested) comments may not be working quite as desired either. For now this block skips adding line numbers for comment items and performs the rest of its tasks properly.
