### PR TITLE
Functionality improvement, caching self literal as a variable's value

### DIFF
--- a/scssphp/src/Compiler.php
+++ b/scssphp/src/Compiler.php
@@ -1618,6 +1618,15 @@ class Compiler
                     $flags = isset($child[3]) ? $child[3] : [];
                     $isDefault = in_array('!default', $flags);
                     $isGlobal = in_array('!global', $flags);
+                    
+                    if($value[0] === Type::T_SELF):
+                    
+                        if (!empty($out->selectors) && !empty($out->selectors[0][0])) {
+                            $value[2][0] = implode($out->selectors[0][0]);
+                            $value[0] = Type::T_STRING;
+                        } 
+                    
+                    endif;
 
                     if ($isGlobal) {
                         $this->set($name[1], $this->reduce($value), false, $this->rootEnv);
@@ -2817,6 +2826,9 @@ class Compiler
 
                     case Type::T_NULL:
                         $reduced = [Type::T_KEYWORD, ''];
+                        
+                    case Type::T_SELF:
+                        return Type::T_SELF;
                 }
 
                 return $this->compileValue($reduced);

--- a/scssphp/src/Parser.php
+++ b/scssphp/src/Parser.php
@@ -1350,6 +1350,10 @@ class Parser
         ) {
             return true;
         }
+        
+        if ($this->selfCache($out)) {
+            return true;
+        }
 
         if ($this->keyword($keyword)) {
             if ($keyword === 'null') {
@@ -2202,6 +2206,26 @@ class Parser
 
         return false;
     }
+    
+    /**
+     * Parse current value of self (&) literal
+     *
+     * @param array $out
+     *
+     * @return boolean
+     */
+     protected function selfCache(&$out) {
+
+        $s = $this->seek();
+
+        if ($this->literal('&')) {
+            $out = [Type::T_SELF, '', [Type::T_SELF]];
+            
+            return true;
+        }
+
+        return false;
+     }
 
     /**
      * Parse a keyword


### PR DESCRIPTION
This has been a change that I've been running for some months and would like to see it in the master release, based on https://css-tricks.com/snippets/sass/caching-current-selector-sass/.

When you declare a variable such as...

`$this: &;`

the result will be to store the current selector at that point, with the correct variable scope for the position within nested selectors.

Usage is for when using BEM naming systems and requiring the reference to a parent or ancestor selector within your child selector, for example:

`.parent--alternate .parent__child { .. }`

By allowing the use of this pattern such a selector could be created within the ".parent__child" block using:

`#{$this}--alternate & { .. }`

rather than:

`.parent--alternate & { .. }`

Thus allowing some portability and DRY code.
