### PR TITLE
If cache directory doesn't exist, create it.

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -61,6 +61,9 @@ class Wp_Scss {
       function compiler($in, $out, $instance) {
         global $scssc, $cache;
 
+        if (!file_exists($cache)) {
+          mkdir($cache, 0644);
+        }
         if (is_writable($cache)) {
           try {
 	          $map = basename($out) . '.map';


### PR DESCRIPTION
I've been using this plugin and over the past couple of updates the cache directory seems to just vanish. There should be a check to see if the cache directory exists before warning that the permissions are incorrect.