### PR TITLE
Added function_exists( 'compiler' ) check for function compiler()

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -58,6 +58,7 @@ class Wp_Scss {
 
       //Compiler - Takes scss $in and writes compiled css to $out file
       // catches errors and puts them the object's compiled_errors property
+      if (function_exists( 'compiler' ) {
       function compiler($in, $out, $instance) {
         global $scssc, $cache;
 
@@ -89,6 +90,7 @@ class Wp_Scss {
           );
           array_push($instance->compile_errors, $errors);
         }
+      }
       }
 
       $input_files = array();


### PR DESCRIPTION
I wrote code that hooks into WP-SCSS from the child theme and causes both the parent and child theme to compile. I was getting a "cannot redeclare function compiler()" error.

I wrapped function compiler() with a function_exists( 'compiler' ) check and that solved the problem. Would you mind putting this in the next release?

Love the plugin by the way <3.