### PR TITLE
Always recompile setting

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -10,7 +10,7 @@ class Wp_Scss {
    * @var string
    * @access public
    */
-  public $scss_dir, $css_dir, $compile_method, $scssc, $compile_errors, $sourcemaps;
+  public $scss_dir, $css_dir, $compile_method, $always_recompile, $scssc, $compile_errors, $sourcemaps;
 
   /**
    * Set values for Wp_Scss::properties
@@ -158,7 +158,8 @@ class Wp_Scss {
    * @return bool - true if compiling is needed
    */
   public function needs_compiling() {
-    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE || $instance->always_recompile) {
+    global $always_recompile;
+    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE || $always_recompile) {
       return true;
     }
 

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -23,13 +23,14 @@ class Wp_Scss {
    *
    * @var array compile_errors - catches errors from compile
    */
-  public function __construct ($scss_dir, $css_dir, $compile_method, $sourcemaps) {
+  public function __construct ($scss_dir, $css_dir, $compile_method, $always_recompile, $sourcemaps) {
     global $scssc;
-    $this->scss_dir       = $scss_dir;
-    $this->css_dir        = $css_dir;
-    $this->compile_method = $compile_method;
-    $this->compile_errors = array();
-    $scssc                = new Compiler();
+    $this->scss_dir         = $scss_dir;
+    $this->css_dir          = $css_dir;
+    $this->compile_method   = $compile_method;
+    $this->always_recompile = $always_recompile;
+    $this->compile_errors   = array();
+    $scssc                  = new Compiler();
 
     $scssc->setFormatter( $compile_method );
     $scssc->setImportPaths( $this->scss_dir );
@@ -157,7 +158,7 @@ class Wp_Scss {
    * @return bool - true if compiling is needed
    */
   public function needs_compiling() {
-    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE) {
+    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE || $instance->always_recompile) {
       return true;
     }
 

--- a/options.php
+++ b/options.php
@@ -184,6 +184,26 @@ class Wp_Scss_Settings
       )
     );
 
+    //  Developer options
+    add_settings_section(
+      'wpscss_developer_section',             // ID
+      'Developer Settings',                   // Title
+      array( $this, 'print_developer_info' ), // Callback
+      'wpscss_options'                        // Page
+    );
+
+    add_settings_field(
+      'wpscss_scss_always_recompile',            // ID
+      'Always Recompile',                        // Title
+      array( $this, 'input_checkbox_callback' ), // Callback
+      'wpscss_options',                          // Page
+      'wpscss_developer_section',                // Section
+      array(                                     // args
+        'name' => 'always_recompile',
+      )
+    );
+
+
   }
 
   /**
@@ -217,6 +237,9 @@ class Wp_Scss_Settings
   }
   public function print_enqueue_info() {
     print 'WP-SCSS can enqueue your css stylesheets in the header automatically.';
+  }
+  public function print_developer_info() {
+    print 'Quickly change developer settings. Best not to use on production websites.';
   }
 
   /**

--- a/options.php
+++ b/options.php
@@ -184,39 +184,24 @@ class Wp_Scss_Settings
       )
     );
 
-    //  Developer options
+    //  Development options
     add_settings_section(
-      'wpscss_developer_section',             // ID
-      'Developer Settings',                   // Title
-      array( $this, 'print_developer_info' ), // Callback
-      'wpscss_options'                        // Page
+      'wpscss_development_section', // ID
+      'Development Settings',       // Title
+      '',                         // Callback
+      'wpscss_options'            // Page
     );
 
-    if(WP_SCSS_ALWAYS_RECOMPILE){
-      add_settings_field(
-        'wpscss_scss_always_recompile',                     // ID
-        'Always Recompile (disabled by WP_SCSS_ALWAYS_RECOMPILE)',                                 // Title
-        array( $this, 'input_checkbox_disabled_callback' ), // Callback
-        'wpscss_options',                                   // Page
-        'wpscss_developer_section',                         // Section
-        array(                                              // args
-          'name' => 'always_recompile',
-        )
-      );
-    }else{
-      add_settings_field(
-        'wpscss_scss_always_recompile',            // ID
-        'Always Recompile',                        // Title
-        array( $this, 'input_checkbox_callback' ), // Callback
-        'wpscss_options',                          // Page
-        'wpscss_developer_section',                // Section
-        array(                                     // args
-          'name' => 'always_recompile',
-        )
-      );
-    }
-
-
+    add_settings_field(
+      'wpscss_scss_always_recompile',            // ID
+      'Always Recompile',                        // Title
+      array( $this, 'input_checkbox_callback' ), // Callback
+      'wpscss_options',                          // Page
+      'wpscss_development_section',                // Section
+      array(                                     // args
+        'name' => 'always_recompile',
+      )
+    );
   }
 
   /**
@@ -251,9 +236,6 @@ class Wp_Scss_Settings
   public function print_enqueue_info() {
     print 'WP-SCSS can enqueue your css stylesheets in the header automatically.';
   }
-  public function print_developer_info() {
-    print 'Quickly change developer settings. Best not to use on production websites.';
-  }
 
   /**
    * Text Fields' Callback
@@ -285,19 +267,15 @@ class Wp_Scss_Settings
    */
   public function input_checkbox_callback( $args ) {
     $this->options = get_option( 'wpscss_options' );
+    $html = "";
+    if($args['name'] == 'always_recompile' && defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE){
+      $html .= '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' . checked( 1, isset( $this->options[esc_attr( $args['name'] )] ) ? $this->options[esc_attr( $args['name'] )] : 1, false ) . ' disabled=disabled/>';
+      $html .= '<label for="' . esc_attr( $args['name'] ) . '">Currently overwritten by constant <code>WP_SCSS_ALWAYS_RECOMPILE</code></label>';
+    }else{
+      $html .= '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' . checked( 1, isset( $this->options[esc_attr( $args['name'] )] ) ? $this->options[esc_attr( $args['name'] )] : 0, false ) . '/>';
+      $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
+    }
 
-    $html = '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' . checked( 1, isset( $this->options[esc_attr( $args['name'] )] ) ? $this->options[esc_attr( $args['name'] )] : 0, false ) . '/>';
-    $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
-
-    echo $html;
-  }
-
-  public function input_checkbox_disabled_callback( $args ) {
-    $this->options = get_option( 'wpscss_options' );
-
-    $html = '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' .
-      checked( 1, true ) . 'disabled="disabled"/>';
-    $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
 
     echo $html;
   }

--- a/options.php
+++ b/options.php
@@ -192,16 +192,29 @@ class Wp_Scss_Settings
       'wpscss_options'                        // Page
     );
 
-    add_settings_field(
-      'wpscss_scss_always_recompile',            // ID
-      'Always Recompile',                        // Title
-      array( $this, 'input_checkbox_callback' ), // Callback
-      'wpscss_options',                          // Page
-      'wpscss_developer_section',                // Section
-      array(                                     // args
-        'name' => 'always_recompile',
-      )
-    );
+    if(WP_SCSS_ALWAYS_RECOMPILE){
+      add_settings_field(
+        'wpscss_scss_always_recompile',                     // ID
+        'Always Recompile (disabled by WP_SCSS_ALWAYS_RECOMPILE)',                                 // Title
+        array( $this, 'input_checkbox_disabled_callback' ), // Callback
+        'wpscss_options',                                   // Page
+        'wpscss_developer_section',                         // Section
+        array(                                              // args
+          'name' => 'always_recompile',
+        )
+      );
+    }else{
+      add_settings_field(
+        'wpscss_scss_always_recompile',            // ID
+        'Always Recompile',                        // Title
+        array( $this, 'input_checkbox_callback' ), // Callback
+        'wpscss_options',                          // Page
+        'wpscss_developer_section',                // Section
+        array(                                     // args
+          'name' => 'always_recompile',
+        )
+      );
+    }
 
 
   }
@@ -274,6 +287,16 @@ class Wp_Scss_Settings
     $this->options = get_option( 'wpscss_options' );
 
     $html = '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' . checked( 1, isset( $this->options[esc_attr( $args['name'] )] ) ? $this->options[esc_attr( $args['name'] )] : 0, false ) . '/>';
+    $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
+
+    echo $html;
+  }
+
+  public function input_checkbox_disabled_callback( $args ) {
+    $this->options = get_option( 'wpscss_options' );
+
+    $html = '<input type="checkbox" id="' . esc_attr( $args['name'] ) . '" name="wpscss_options[' . esc_attr( $args['name'] ) . ']" value="1"' .
+      checked( 1, true ) . 'disabled="disabled"/>';
     $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
 
     echo $html;

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,8 @@ Alternatively, you can include [Bourbon](https://github.com/thoughtbot/bourbon) 
 This plugin will only work with .scss format.
 
 ## Changelog
+* 2.0.2
+  * Added option in settings to enable an 'always recompile' flag. Suggestion by [bick](https://github.com/ConnectThink/WP-SCSS/issues/151)
 * 2.0.1
   * Bugfix to add filter for option_wpscss_options to remove Leafo if stored in DB. Thanks to [kinsky-org](https://github.com/ConnectThink/WP-SCSS/issues/157) for pointing this out
   * Saving plugin settings will update DB with correct value.

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -163,10 +163,10 @@ $wpscss_settings = array(
   'scss_dir'         => WPSCSS_THEME_DIR . $scss_dir_setting,
   'css_dir'          => WPSCSS_THEME_DIR . $css_dir_setting,
   'compiling'        => isset($wpscss_options['compiling_options']) ? $wpscss_options['compiling_options'] : 'ScssPhp\ScssPhp\Formatter\Expanded',
-  'always_recompile' => isset($wpscss_options['always_recompile']) ? $wpscss_options['always_recompile'] : false
-  'errors'           => isset($wpscss_options['errors']) ? $wpscss_options['errors'] : 'show',
+  'always_recompile' => isset($wpscss_options['always_recompile'])  ? $wpscss_options['always_recompile']  : false,
+  'errors'           => isset($wpscss_options['errors'])            ? $wpscss_options['errors']            : 'show',
   'sourcemaps'       => isset($wpscss_options['sourcemap_options']) ? $wpscss_options['sourcemap_options'] : 'SOURCE_MAP_NONE',
-  'enqueue'          => isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
+  'enqueue'          => isset($wpscss_options['enqueue'])           ? $wpscss_options['enqueue']           : 0
 );
 
 
@@ -182,6 +182,7 @@ $wpscss_compiler = new Wp_Scss(
   $wpscss_settings['scss_dir'],
   $wpscss_settings['css_dir'],
   $wpscss_settings['compiling'],
+  $wpscss_settings['always_recompile'],
   $wpscss_settings['sourcemaps']
 );
 

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -46,7 +46,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '2.0.1');
+  define('WPSCSS_VERSION_NUM', '2.0.2');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -160,12 +160,13 @@ if( $scss_dir_setting == false || $css_dir_setting == false ) {
 
 // Plugin Settings
 $wpscss_settings = array(
-  'scss_dir'   =>  WPSCSS_THEME_DIR . $scss_dir_setting,
-  'css_dir'    =>  WPSCSS_THEME_DIR . $css_dir_setting,
-  'compiling'  =>  isset($wpscss_options['compiling_options']) ? $wpscss_options['compiling_options'] : 'ScssPhp\ScssPhp\Formatter\Expanded',
-  'errors'     =>  isset($wpscss_options['errors']) ? $wpscss_options['errors'] : 'show',
-  'sourcemaps' =>  isset($wpscss_options['sourcemap_options']) ? $wpscss_options['sourcemap_options'] : 'SOURCE_MAP_NONE',
-  'enqueue'    =>  isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
+  'scss_dir'         => WPSCSS_THEME_DIR . $scss_dir_setting,
+  'css_dir'          => WPSCSS_THEME_DIR . $css_dir_setting,
+  'compiling'        => isset($wpscss_options['compiling_options']) ? $wpscss_options['compiling_options'] : 'ScssPhp\ScssPhp\Formatter\Expanded',
+  'always_recompile' => isset($wpscss_options['always_recompile']) ? $wpscss_options['always_recompile'] : false
+  'errors'           => isset($wpscss_options['errors']) ? $wpscss_options['errors'] : 'show',
+  'sourcemaps'       => isset($wpscss_options['sourcemap_options']) ? $wpscss_options['sourcemap_options'] : 'SOURCE_MAP_NONE',
+  'enqueue'          => isset($wpscss_options['enqueue']) ? $wpscss_options['enqueue'] : 0
 );
 
 


### PR DESCRIPTION
Gives option in settings to allow for always recompile.
the WP settings of `WP_SCSS_ALWAYS_RECOMPILE` will continue to work as well.