### PR TITLE
Set soureRoot to home_url('/') when setSourceMapOptions is called

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -74,7 +74,7 @@ class Wp_Scss {
               'sourceMapWriteTo' => $instance->css_dir . $map, // absolute path to a file to write the map to
               'sourceMapURL' => $map, // url of the map
               'sourceMapBasepath' => rtrim(ABSPATH, '/'), // base path for filename normalization
-              'sourceRoot' => '/', // This value is prepended to the individual entries in the 'source' field.
+              'sourceRoot' => home_url('/'), // This value is prepended to the individual entries in the 'source' field.
             ));
 
             $css = $scssc->compile(file_get_contents($in), $in);

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,8 @@ Alternatively, you can include [Bourbon](https://github.com/thoughtbot/bourbon) 
 This plugin will only work with .scss format.
 
 ## Changelog
+* 2.1.4
+  * Set source URL to be home_url('/') not simply `/`. Issue found by [realjjaveweb](https://github.com/ConnectThink/WP-SCSS/issues/128)
 * 2.1.3
   * Must declare global to use it for $base_compiling_folder.
 * 2.1.2

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.1.3
+ * Version: 2.1.4
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -44,7 +44,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '2.1.3');
+  define('WPSCSS_VERSION_NUM', '2.1.4');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {


### PR DESCRIPTION
Bug fix for #128 