### PR TITLE
use variable with default value when running enqueue_files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,8 @@ Alternatively, you can include [Bourbon](https://github.com/thoughtbot/bourbon) 
 This plugin will only work with .scss format.
 
 ## Changelog
+* 2.1.2
+  * Correction for enqueueing styles not defaulting to get_stylesheet_directory() [Issue](https://github.com/ConnectThink/WP-SCSS/issues/168)
 * 2.1.1
   * Bug fixes after merging 2.0.2 and 2.1.0 defaults worked, but new options did not. [Shadoath](https://github.com/ConnectThink/WP-SCSS/issues/165)
 * 2.1.0

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -300,7 +300,7 @@ function wpscss_handle_errors() {
 if ( $wpscss_settings['enqueue'] == '1' ) {
   function wpscss_enqueue_styles() {
     global $wpscss_compiler, $wpscss_options;
-    $wpscss_compiler->enqueue_files($wpscss_options['base_compiling_folder'], $wpscss_options['css_dir']);
+    $wpscss_compiler->enqueue_files($base_compiling_folder, $wpscss_options['css_dir']);
   }
   add_action('wp_enqueue_scripts', 'wpscss_enqueue_styles', 50);
 }

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -44,7 +44,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '2.1.1');
+  define('WPSCSS_VERSION_NUM', '2.1.2');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {


### PR DESCRIPTION
Missing backward compatibility when upgrading to 2.2.1 due to `$wpscss_options['base_compiling_folder']` not yet having a value, using `$base_compiling_folder` [has default set if setting value](https://github.com/ConnectThink/WP-SCSS/compare/defaults?expand=1#diff-c93905c184392d71f40933c8dbf9017e60fac7fbfe23f178d32d0d66ab17a7a8L127) is not defined.
