### PR TITLE
Defer to WordPress for URLs instead of trying to guess them

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -211,13 +211,15 @@ class Wp_Scss {
    *                      so it can be used in a url, not path
    */
   public function enqueue_files($base_folder_path, $css_folder) {
-    // We use realpath() to normalize any forward, backward, or trailing slack inconsistencies.
-    $relative_path = explode(realpath(get_home_path()), realpath($base_folder_path))[1];
-
-    // In case we're on a Windows machine
-    $relative_path = str_replace('\\', '/', $relative_path);
-
-    $enqueue_base_url = get_home_url() . $relative_path;
+    if($base_folder_path === wp_get_upload_dir()['basedir']){
+      $enqueue_base_url = wp_get_upload_dir()['baseurl'];
+    }
+    else if($base_folder_path === WPSCSS_PLUGIN_DIR){
+      $enqueue_base_url = plugins_url();
+    }
+    else{ // assume get_stylesheet_directory()
+      $enqueue_base_url = get_stylesheet_directory_uri();
+    }
 
     foreach( new DirectoryIterator($this->css_dir) as $stylesheet ) {
       if ( pathinfo($stylesheet->getFilename(), PATHINFO_EXTENSION) == 'css' ) {

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -217,7 +217,10 @@ class Wp_Scss {
     else if($base_folder_path === WPSCSS_PLUGIN_DIR){
       $enqueue_base_url = plugins_url();
     }
-    else{ // assume get_stylesheet_directory()
+    else if($base_folder_path === get_template_directory()){
+      $enqueue_base_url = get_template_directory_uri();
+    }
+    else{ // assume default of get_stylesheet_directory()
       $enqueue_base_url = get_stylesheet_directory_uri();
     }
 


### PR DESCRIPTION
I ran into another URL issue when an [alternate core directory](https://www.google.com/search?q=wordpress+alternate+core+directory&rlz=1C1CHBF_enUS862US862&oq=wordpress+alternate+core+directory&aqs=chrome..69i57j69i64.7524j0j7&sourceid=chrome&ie=UTF-8) is used.  I think perhaps we should defer to WordPress for all base URLs, instead of having our own logic to generate them, since it seems to be difficult to cover all edge cases.  What do you think of this approach?