### PR TITLE
Allow compile() from outside the plugin

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -30,7 +30,7 @@ class Wp_Scss {
     $this->css_dir          = $css_dir;
     $this->compile_method   = $compile_method;
     $this->compile_errors   = array();
-    $this->scssc                  = new Compiler();
+    $this->scssc            = new Compiler();
 
     $this->cache = WPSCSS_PLUGIN_DIR . '/cache/';
 

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -159,7 +159,7 @@ class Wp_Scss {
 
         $css = $this->scssc->compile(file_get_contents($in), $in);
 
-        file_put_contents($this->cache.basename($out), $css);
+        file_put_contents($this->cache . basename($out), $css);
       } catch (Exception $e) {
         $errors = array (
           'file' => basename($in),

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -112,8 +112,8 @@ class Wp_Scss {
       if  ( is_writable($this->css_dir) ) {
         foreach (new DirectoryIterator($this->cache) as $this->cache_file) {
           if ( pathinfo($this->cache_file->getFilename(), PATHINFO_EXTENSION) == 'css') {
-            file_put_contents($this->css_dir.$this->cache_file, file_get_contents($this->cache.$this->cache_file));
-            unlink($this->cache.$this->cache_file->getFilename()); // Delete file on successful write
+            file_put_contents($this->css_dir . $this->cache_file, file_get_contents($this->cache . $this->cache_file));
+            unlink($this->cache . $this->cache_file->getFilename()); // Delete file on successful write
           }
         }
       } else {

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -101,9 +101,9 @@ class Wp_Scss {
 
     // For each input file, find matching css file and compile
     foreach ($input_files as $scss_file) {
-      $input = $this->scss_dir.$scss_file;
-      $outputName = preg_replace("/\.[^$]*/",".css", $scss_file);
-      $output = $this->css_dir.$outputName;
+      $input = $this->scss_dir . $scss_file;
+      $outputName = preg_replace("/\.[^$]*/", ".css", $scss_file);
+      $output = $this->css_dir . $outputName;
 
       $this->compiler($input, $output, $this);
     }

--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -9,9 +9,9 @@ class Wp_Scss {
    * Compiling preferences properites
    *
    * @var string
-   * @access public
+   * @access private
    */
-  public $scss_dir, $css_dir, $compile_method, $scssc, $compile_errors, $sourcemaps;
+  private $scss_dir, $css_dir, $compile_method, $scssc, $compile_errors, $sourcemaps, $cache;
 
   /**
    * Set values for Wp_Scss::properties
@@ -25,26 +25,61 @@ class Wp_Scss {
    * @var array compile_errors - catches errors from compile
    */
   public function __construct ($scss_dir, $css_dir, $compile_method, $sourcemaps) {
-    global $scssc;
+  
     $this->scss_dir         = $scss_dir;
     $this->css_dir          = $css_dir;
     $this->compile_method   = $compile_method;
     $this->compile_errors   = array();
-    $scssc                  = new Compiler();
+    $this->scssc                  = new Compiler();
 
-    $scssc->setFormatter( $compile_method );
-    $scssc->setImportPaths( $this->scss_dir );
+    $this->cache = WPSCSS_PLUGIN_DIR . '/cache/';
+
+    $this->scssc->setFormatter( $compile_method );
+    $this->scssc->setImportPaths( $this->scss_dir );
 
     $this->sourcemaps = $sourcemaps;
+  }
+
+  /**
+   * METHOD GET SCSS DIRECTORY
+   * Returns the stored SCSS directory for this compile instance
+   *
+   * @return string - Value of the SCSS directory
+   *
+   * @access public
+   */
+  public function get_scss_dir() {
+    return $this->scss_dir;
+  }
+
+  /**
+   * METHOD GET CSS DIRECTORY
+   * Returns the stored CSS directory for this compile instance
+   *
+   * @return string - Value of the CSS directory
+   *
+   * @access public
+   */
+  public function get_css_dir() {
+    return $this->css_dir;
+  }
+
+  /**
+   * METHOD GET CSS DIRECTORY
+   * Returns the stored CSS directory for this compile instance
+   *
+   * @return array - List of errors from the compile process, if any
+   *
+   * @access public
+   */
+  public function get_compile_errors() {
+    return $this->compile_errors;
   }
 
   /**
    * METHOD COMPILE
    * Loops through scss directory and compilers files that end
    * with .scss and do not have '_' in front.
-   *
-   * @function compiler - passes input content through scssphp,
-   *                      puts compiled css into cache file
    *
    * @var array input_files - array of .scss files with no '_' in front
    * @var array sdir_arr - an array of all the files in the scss directory
@@ -54,90 +89,92 @@ class Wp_Scss {
    * @access public
    */
   public function compile() {
-    global $scssc, $cache;
-    $cache = WPSCSS_PLUGIN_DIR . '/cache/';
+   
+    $input_files = array();
 
-    //Compiler - Takes scss $in and writes compiled css to $out file
-    // catches errors and puts them the object's compiled_errors property
-    if (!function_exists( 'compiler' )) {
-      function compiler($in, $out, $instance) {
-        global $scssc, $cache;
+    // Loop through directory and get .scss file that do not start with '_'
+    foreach(new DirectoryIterator($this->scss_dir) as $file) {
+      if (substr($file, 0, 1) != "_" && pathinfo($file->getFilename(), PATHINFO_EXTENSION) == 'scss') {
+        array_push($input_files, $file->getFilename());
+      }
+    }
 
-        if (!file_exists($cache)) {
-          mkdir($cache, 0644);
-        }
-        if (is_writable($cache)) {
-          try {
-            $map = basename($out) . '.map';
-            $scssc->setSourceMap(constant('ScssPhp\ScssPhp\Compiler::' . $instance->sourcemaps));
-            $scssc->setSourceMapOptions(array(
-              'sourceMapWriteTo' => $instance->css_dir . $map, // absolute path to a file to write the map to
-              'sourceMapURL' => $map, // url of the map
-              'sourceMapBasepath' => rtrim(ABSPATH, '/'), // base path for filename normalization
-              'sourceRoot' => home_url('/'), // This value is prepended to the individual entries in the 'source' field.
-            ));
+    // For each input file, find matching css file and compile
+    foreach ($input_files as $scss_file) {
+      $input = $this->scss_dir.$scss_file;
+      $outputName = preg_replace("/\.[^$]*/",".css", $scss_file);
+      $output = $this->css_dir.$outputName;
 
-            $css = $scssc->compile(file_get_contents($in), $in);
+      $this->compiler($input, $output, $this);
+    }
 
-            file_put_contents($cache.basename($out), $css);
-          } catch (Exception $e) {
-            $errors = array (
-              'file' => basename($in),
-              'message' => $e->getMessage(),
-            );
-            array_push($instance->compile_errors, $errors);
+    if (count($this->compile_errors) < 1) {
+      if  ( is_writable($this->css_dir) ) {
+        foreach (new DirectoryIterator($this->cache) as $this->cache_file) {
+          if ( pathinfo($this->cache_file->getFilename(), PATHINFO_EXTENSION) == 'css') {
+            file_put_contents($this->css_dir.$this->cache_file, file_get_contents($this->cache.$this->cache_file));
+            unlink($this->cache.$this->cache_file->getFilename()); // Delete file on successful write
           }
-        } else {
-          $errors = array (
-            'file' => $cache,
-            'message' => "File Permission Error, permission denied. Please make the cache directory writable."
-          );
-          array_push($instance->compile_errors, $errors);
         }
+      } else {
+        $errors = array(
+          'file' => 'CSS Directory',
+          'message' => "File Permissions Error, permission denied. Please make your CSS directory writable."
+        );
+        array_push($this->compile_errors, $errors);
       }
-
-      $input_files = array();
-      // Loop through directory and get .scss file that do not start with '_'
-      foreach(new DirectoryIterator($this->scss_dir) as $file) {
-        if (substr($file, 0, 1) != "_" && pathinfo($file->getFilename(), PATHINFO_EXTENSION) == 'scss') {
-          array_push($input_files, $file->getFilename());
-        }
-      }
-
-      // For each input file, find matching css file and compile
-      foreach ($input_files as $scss_file) {
-        $input = $this->scss_dir.$scss_file;
-        $outputName = preg_replace("/\.[^$]*/",".css", $scss_file);
-        $output = $this->css_dir.$outputName;
-
-        compiler($input, $output, $this);
-      }
-
-      if (count($this->compile_errors) < 1) {
-        if  ( is_writable($this->css_dir) ) {
-          foreach (new DirectoryIterator($cache) as $cache_file) {
-            if ( pathinfo($cache_file->getFilename(), PATHINFO_EXTENSION) == 'css') {
-              file_put_contents($this->css_dir.$cache_file, file_get_contents($cache.$cache_file));
-              unlink($cache.$cache_file->getFilename()); // Delete file on successful write
-            }
-          }
-        } else {
-          $errors = array(
-            'file' => 'CSS Directory',
-            'message' => "File Permissions Error, permission denied. Please make your CSS directory writable."
-          );
-          array_push($this->compile_errors, $errors);
-        }
-      }
-    }else{
-      $errors = array (
-        'file' => 'SCSS compiler',
-        'message' => "Compiling Error, function 'compiler' already exists."
-      );
-      array_push($this->compile_errors, $errors);
     }
   }
 
+  /**
+   * METHOD COMPILER
+   * Takes scss $in and writes compiled css to $out file
+   * catches errors and puts them the object's compiled_errors property
+   *
+   * @function compiler - passes input content through scssphp,
+   *                      puts compiled css into cache file
+   *
+   * @var array input_files - array of .scss files with no '_' in front
+   * @var array sdir_arr - an array of all the files in the scss directory
+   *
+   * @return nothing - Puts successfully compiled css into appropriate location
+   *                   Puts error in 'compile_errors' property
+   * @access public
+   */
+  private function compiler($in, $out, $instance) {
+
+    if (!file_exists($this->cache)) {
+      mkdir($this->cache, 0644);
+    }
+    if (is_writable($this->cache)) {
+      try {
+        $map = basename($out) . '.map';
+        $this->scssc->setSourceMap(constant('ScssPhp\ScssPhp\Compiler::' . $instance->sourcemaps));
+        $this->scssc->setSourceMapOptions(array(
+          'sourceMapWriteTo' => $instance->css_dir . $map, // absolute path to a file to write the map to
+          'sourceMapURL' => $map, // url of the map
+          'sourceMapBasepath' => rtrim(ABSPATH, '/'), // base path for filename normalization
+          'sourceRoot' => home_url('/'), // This value is prepended to the individual entries in the 'source' field.
+        ));
+
+        $css = $this->scssc->compile(file_get_contents($in), $in);
+
+        file_put_contents($this->cache.basename($out), $css);
+      } catch (Exception $e) {
+        $errors = array (
+          'file' => basename($in),
+          'message' => $e->getMessage(),
+        );
+        array_push($instance->compile_errors, $errors);
+      }
+    } else {
+      $errors = array (
+        'file' => $this->cache,
+        'message' => "File Permission Error, permission denied. Please make the cache directory writable."
+      );
+      array_push($instance->compile_errors, $errors);
+    }
+  }
 
   /**
    * METHOD NEEDS_COMPILING
@@ -245,7 +282,7 @@ class Wp_Scss {
   }
 
   public function set_variables(array $variables) {
-    global $scssc;
-    $scssc->setVariables($variables);
+
+    $this->scssc->setVariables($variables);
   }
 } // End Wp_Scss Class

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -276,7 +276,7 @@ function wpscss_handle_errors() {
   } else { // Hide errors and print them to a log file.
     foreach ($compile_errors as $error) {
       $error_string = date('m/d/y g:i:s', time()) .': ';
-      $error_string .= $error['file'] .' - '. $error['message'] . PHP_EOL;
+      $error_string .= $error['file'] . ' - ' . $error['message'] . PHP_EOL;
       file_put_contents($log_file, $error_string, FILE_APPEND);
       $error_string = "";
     }

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.1.6
+ * Version: 2.1.7
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -220,7 +220,7 @@ function wp_scss_compile() {
  * half of entries in the file.
  */
 
-$log_file = $wpscss_compiler->scss_dir.'error_log.log';
+$log_file = $wpscss_compiler->get_scss_dir() . 'error_log.log';
 
 function wpscss_error_styles() {
   echo
@@ -266,13 +266,15 @@ function wpscss_settings_show_errors($errors) {
 function wpscss_handle_errors() {
   global $wpscss_settings, $log_file, $wpscss_compiler;
   // Show to logged in users: All the methods for checking user login are set up later in the WP flow, so this only checks that there is a cookie
-  if ( !is_admin() && $wpscss_settings['errors'] === 'show-logged-in' && !empty($_COOKIE[LOGGED_IN_COOKIE]) && count($wpscss_compiler->compile_errors) > 0) {
+
+  $compile_errors = $wpscss_compiler->get_compile_errors();
+  if ( !is_admin() && $wpscss_settings['errors'] === 'show-logged-in' && !empty($_COOKIE[LOGGED_IN_COOKIE]) && count($compile_errors) > 0) {
     wpscss_settings_show_errors($wpscss_compiler->compile_errors);
     // Show in the header to anyone
   } else if ( !is_admin() && $wpscss_settings['errors'] === 'show' && count($wpscss_compiler->compile_errors) > 0) {
     wpscss_settings_show_errors($wpscss_compiler->compile_errors);
   } else { // Hide errors and print them to a log file.
-    foreach ($wpscss_compiler->compile_errors as $error) {
+    foreach ($compile_errors as $error) {
       $error_string = date('m/d/y g:i:s', time()) .': ';
       $error_string .= $error['file'] .' - '. $error['message'] . PHP_EOL;
       file_put_contents($log_file, $error_string, FILE_APPEND);

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.1.7
+ * Version: 2.1.6
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -269,10 +269,10 @@ function wpscss_handle_errors() {
 
   $compile_errors = $wpscss_compiler->get_compile_errors();
   if ( !is_admin() && $wpscss_settings['errors'] === 'show-logged-in' && !empty($_COOKIE[LOGGED_IN_COOKIE]) && count($compile_errors) > 0) {
-    wpscss_settings_show_errors($wpscss_compiler->compile_errors);
+    wpscss_settings_show_errors($compile_errors);
     // Show in the header to anyone
-  } else if ( !is_admin() && $wpscss_settings['errors'] === 'show' && count($wpscss_compiler->compile_errors) > 0) {
-    wpscss_settings_show_errors($wpscss_compiler->compile_errors);
+  } else if ( !is_admin() && $wpscss_settings['errors'] === 'show' && count($compile_errors) > 0) {
+    wpscss_settings_show_errors($compile_errors);
   } else { // Hide errors and print them to a log file.
     foreach ($compile_errors as $error) {
       $error_string = date('m/d/y g:i:s', time()) .': ';


### PR DESCRIPTION
Cleaned up the class-wp-scss.php file primarily to allow for multiple instances of the Wp_Scss class without conflict with internal variables. 

Removed almost all global variable references to create a more class based/object oriented structure, including removing direct calls to public class variables and replacing with function calls to retrieve private variables.