### PR TITLE
Fix always recompile bug

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -189,7 +189,7 @@ class Wp_Scss {
    */
   public function needs_compiling() {
     global $wpscss_settings;
-    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE || isset($wpscss_settings['always_recompile']) ? $wpscss_settings['always_recompile'] === "1" : false) {
+    if (defined('WP_SCSS_ALWAYS_RECOMPILE') && WP_SCSS_ALWAYS_RECOMPILE || (isset($wpscss_settings['always_recompile']) ? $wpscss_settings['always_recompile'] === "1" : false)) {
       return true;
     }
 


### PR DESCRIPTION
Added brackets around the ternary operator to ensure the logic still functions. Previously would return false even if WP_SCSS_ALWAYS_RECOMPILE was defined and true.