### PR TITLE
WP-SCSS required plugin updates

### DIFF
--- a/options.php
+++ b/options.php
@@ -40,7 +40,7 @@ class Wp_Scss_Settings {
     <div class="wrap">
         <h2>WP-SCSS Settings</h2>
         <p>
-          <span class="version">Version <em><?php echo get_option('wpscss_version'); ?></em>
+          <span class="version">Version <em><?php echo wp_kses(get_option('wpscss_version'), array()); ?></em>
           <br/>
           <span class="author">By: <a href="http://connectthink.com" target="_blank">Connect Think</a></span>
           <br/>
@@ -262,6 +262,9 @@ class Wp_Scss_Settings {
     );
   }
 
+  public function input_kses_allowed_array(){
+    return array( 'select' => array(), 'option' => array(), 'input' => array(), 'label' => array() );
+  }
   /**
    * Select Boxes' Callbacks
    */
@@ -274,7 +277,7 @@ class Wp_Scss_Settings {
     }
     $html .= '</select>';
 
-    echo $html;
+    echo wp_kses($html, input_kses_allowed_array());
   }
 
   /**
@@ -291,7 +294,6 @@ class Wp_Scss_Settings {
       $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
     }
 
-
-    echo $html;
+    echo wp_kses($html, input_kses_allowed_array());
   }
 }

--- a/options.php
+++ b/options.php
@@ -262,9 +262,6 @@ class Wp_Scss_Settings {
     );
   }
 
-  public function kses_allowed_html_for_inputs(){
-    return array( 'select' => array(), 'option' => array(), 'input' => array(), 'label' => array() );
-  }
   /**
    * Select Boxes' Callbacks
    */
@@ -277,7 +274,7 @@ class Wp_Scss_Settings {
     }
     $html .= '</select>';
 
-    echo wp_kses($html, kses_allowed_html_for_inputs());
+    echo wp_kses($html, array( 'select' => array(), 'option' => array()));
   }
 
   /**
@@ -294,6 +291,6 @@ class Wp_Scss_Settings {
       $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
     }
 
-    echo wp_kses($html, kses_allowed_html_for_inputs());
+    echo wp_kses($html, array('input' => array(), 'label' => array() ));
   }
 }

--- a/options.php
+++ b/options.php
@@ -262,7 +262,7 @@ class Wp_Scss_Settings {
     );
   }
 
-  public function input_kses_allowed_array(){
+  public function kses_allowed_html_for_inputs(){
     return array( 'select' => array(), 'option' => array(), 'input' => array(), 'label' => array() );
   }
   /**
@@ -277,7 +277,7 @@ class Wp_Scss_Settings {
     }
     $html .= '</select>';
 
-    echo wp_kses($html, input_kses_allowed_array());
+    echo wp_kses($html, kses_allowed_html_for_inputs());
   }
 
   /**
@@ -294,6 +294,6 @@ class Wp_Scss_Settings {
       $html .= '<label for="' . esc_attr( $args['name'] ) . '"></label>';
     }
 
-    echo wp_kses($html, input_kses_allowed_array());
+    echo wp_kses($html, kses_allowed_html_for_inputs());
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,8 @@ This plugin will only work with .scss format.
 
 ## Changelog
 
-
+- 2.3.2
+  - Add wp_kses() to echos with potential user input [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/208)
 - 2.3.1
   - Wrap check for WP_SCSS_ALWAYS_RECOMPILE with () [niaccurshi](https://github.com/ConnectThink/WP-SCSS/pull/199)
 - 2.3.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: connectthink, sky-bolt
 Tags: sass, scss, css, ScssPhp
 Plugin URI: https://github.com/ConnectThink/WP-SCSS
 Requires at least: 3.0.1
-Tested up to: 5.7.1
+Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 2.3.1
 License: GPLv3 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/ConnectThink/WP-SCSS
 Requires at least: 3.0.1
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.3.1
+Stable tag: 2.3.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl.html
 
@@ -75,6 +75,9 @@ If you are having issues with the plugin, create an issue on [github](https://gi
 
 
 == Changelog ==
+
+= 2.3.2 =
+  - Add wp_kses() to echos with potential user input [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/208)
 
 = 2.3.1 =
   - Wrap check for WP_SCSS_ALWAYS_RECOMPILE with () [niaccurshi](https://github.com/ConnectThink/WP-SCSS/pull/199)

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -253,12 +253,13 @@ function wpscss_error_styles() {
 }
 
 function wpscss_settings_show_errors($errors) {
+  $allowed_html = array( 'string' => array(), 'br' => array(), 'em' => array() );
   echo '<div class="scss_errors"><pre>';
   echo '<h6 style="margin: 15px 0;">Sass Compiling Error</h6>';
 
   foreach( $errors as $error) {
     echo '<p class="sass_error">';
-    echo '<strong>'. $error['file'] .'</strong> <br/><em>"'. $error['message'] .'"</em>';
+    echo wp_kses('<strong>'. $error['file'] .'</strong> <br/><em>"'. $error['message'] .'"</em>', $allowed_html);
     echo '<p class="sass_error">';
   }
 

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.3.1
+ * Version: 2.3.2
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -44,7 +44,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '2.3.1');
+  define('WPSCSS_VERSION_NUM', '2.3.2');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {


### PR DESCRIPTION
Fixes: 
- Tested Up To Value is Out of Date, Invalid, or Missing
- Variables and options must be escaped when echo'd

