### PR TITLE
Add check to migrate compiling_options only if it exists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ This plugin will only work with .scss format.
 
 - 2.3.4
   - Add check to compiling_options on load() [alianschiavoncini](https://github.com/ConnectThink/WP-SCSS/issues/209)
+  - Add more params to wp_kses in options() [evHaitch ](https://github.com/ConnectThink/WP-SCSS/issues/213)
 - 2.3.3
   - Fix params passed to wp_kses() [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/211)
 - 2.3.2

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Compiling comes in two modes:
 - Compressed - More compressed css. Entire rule block on one line. No indentation.
 - Expanded - Full open css. One line per property. Brackets close on their own line.
 
-**Removed** compiling modes
+**Removed** compiling modes. If you used these in the past you will need to update your settings.
 
 - Nested - Lightly compressed css. Brackets close with css block. Indents to match scss nesting.
 - Compact - Removes all line breaks, unnecessary whitespace, and single-line comments.
@@ -104,6 +104,9 @@ Alternatively, you can include [Bourbon](https://github.com/thoughtbot/bourbon) 
 This plugin will only work with .scss format.
 
 #### Maintainers
+
+- [@shadoath](https://github.com/shadoath)
+- Bug reporters, issues, and pull request contributers metioned below. Thank you.
 
 ## Changelog
 

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,8 @@ This plugin will only work with .scss format.
 
 ## Changelog
 
+- 2.3.4
+  - Add check to compiling_options on load() [alianschiavoncini](https://github.com/ConnectThink/WP-SCSS/issues/209)
 - 2.3.3
   - Fix params passed to wp_kses() [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/211)
 - 2.3.2

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ If you are having issues with the plugin, create an issue on [github](https://gi
 
 = 2.3.4 =
   - Add check to compiling_options on load() [alianschiavoncini](https://github.com/ConnectThink/WP-SCSS/issues/209)
+  - Add more params to wp_kses in options() [evHaitch ](https://github.com/ConnectThink/WP-SCSS/issues/213)
 
 = 2.3.3 =
   - Fix params passed to wp_kses() [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/211)

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/ConnectThink/WP-SCSS
 Requires at least: 3.0.1
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 2.3.3
+Stable tag: 2.3.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl.html
 
@@ -75,6 +75,9 @@ If you are having issues with the plugin, create an issue on [github](https://gi
 
 
 == Changelog ==
+
+= 2.3.4 =
+  - Add check to compiling_options on load() [alianschiavoncini](https://github.com/ConnectThink/WP-SCSS/issues/209)
 
 = 2.3.3 =
   - Fix params passed to wp_kses() [shadoath](https://github.com/ConnectThink/WP-SCSS/pull/211)

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -111,12 +111,14 @@ function wpscss_plugin_action_links($links, $file) {
 
 add_filter('option_wpscss_options', 'wpscss_plugin_db_cleanup');
 function wpscss_plugin_db_cleanup($option_values){
-  $compiling_options = str_replace("Leafo", "ScssPhp", $option_values['compiling_options']);
-  $compiling_options = str_replace("ScssPhp\\ScssPhp\\Formatter\\", "", $compiling_options);
-  $compiling_options = str_replace(["Compact", "Crunched"], "compressed", $compiling_options);
-  $compiling_options = str_replace("Nested", "expanded", $compiling_options);
-  $compiling_options = strtolower($compiling_options);
-  $option_values['compiling_options'] = $compiling_options;
+  if( array_key_exists('compiling_options', $option_values) ) {
+    $compiling_options = str_replace("Leafo", "ScssPhp", $option_values['compiling_options']);
+    $compiling_options = str_replace("ScssPhp\\ScssPhp\\Formatter\\", "", $compiling_options);
+    $compiling_options = str_replace(["Compact", "Crunched"], "compressed", $compiling_options);
+    $compiling_options = str_replace("Nested", "expanded", $compiling_options);
+    $compiling_options = strtolower($compiling_options);
+    $option_values['compiling_options'] = $compiling_options;
+  }
   return $option_values;
 }
 

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 2.3.3
+ * Version: 2.3.4
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -44,7 +44,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '2.3.3');
+  define('WPSCSS_VERSION_NUM', '2.3.4');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {


### PR DESCRIPTION
Based on feedback from issue #209 