### PR TITLE
Use WP variables for path to base compiling folder

### DIFF
--- a/options.php
+++ b/options.php
@@ -87,7 +87,7 @@ class Wp_Scss_Settings {
       $base_folder_options['Child Theme'] = 'Child Theme';
     }
 
-    echo $base_folder_options;
+    /* echo var_dump($base_folder_options); */
 
     add_settings_field(
       'wpscss_base_folder',                    // ID

--- a/options.php
+++ b/options.php
@@ -87,8 +87,6 @@ class Wp_Scss_Settings {
       $base_folder_options['Child Theme'] = 'Child Theme';
     }
 
-    /* echo var_dump($base_folder_options); */
-
     add_settings_field(
       'wpscss_base_folder',                    // ID
       'Base Location',                         // Title
@@ -98,13 +96,7 @@ class Wp_Scss_Settings {
       array(                                   // args
         'name' => 'base_compiling_folder',
         'type' => apply_filters( 'wp_scss_base_compiling_modes',
-        $base_folder_options
-          // array(
-          //   get_template_directory()  => 'Parent theme', // Won't display if no parent theme as it would have duplicate keys in array
-          //   get_stylesheet_directory()  => (get_stylesheet_directory() === get_template_directory() ? 'Current theme' : 'Child theme'),
-          //   wp_get_upload_dir()['basedir'] => 'Uploads directory',
-          //   WPSCSS_PLUGIN_DIR => 'WP-SCSS Plugin',
-          // )
+          $base_folder_options
         )
       )
     );

--- a/options.php
+++ b/options.php
@@ -77,14 +77,14 @@ class Wp_Scss_Settings {
     );
 
     $base_folder_options = array(
-      wp_get_upload_dir()['basedir'] => 'Uploads Directory',
-      WPSCSS_PLUGIN_DIR => 'WP-SCSS Plugin'
+      'Uploads Directory' => 'Uploads Directory',
+      'WP-SCSS Plugin' => 'WP-SCSS Plugin'
     );
     if(get_stylesheet_directory() === get_template_directory()){
-      array_unshift($base_folder_options, array(get_stylesheet_directory() => 'Current Theme'));
+      $base_folder_options['Current Theme'] = 'Current Theme';
     }else{
-      array_unshift($base_folder_options, array(get_template_directory() => 'Parent Theme'));
-      array_unshift($base_folder_options, array(get_stylesheet_directory() => 'Child Theme'));
+      $base_folder_options['Parent Theme'] = 'Parent Theme';
+      $base_folder_options['Child Theme'] = 'Child Theme';
     }
 
     echo $base_folder_options;

--- a/options.php
+++ b/options.php
@@ -76,24 +76,50 @@ class Wp_Scss_Settings {
       'wpscss_options'                    // Page
     );
 
+    $base_folder_options = array(
+      wp_get_upload_dir()['basedir'] => 'Uploads Directory',
+      WPSCSS_PLUGIN_DIR => 'WP-SCSS Plugin'
+    );
+    if(get_stylesheet_directory() === get_template_directory()){
+      array_unshift($base_folder_options, array(get_stylesheet_directory() => 'Current Theme'));
+    }else{
+      array_unshift($base_folder_options, array(get_template_directory() => 'Parent Theme'));
+      array_unshift($base_folder_options, array(get_stylesheet_directory() => 'Child Theme'));
+    }
+
+    echo $base_folder_options;
+
     add_settings_field(
       'wpscss_base_folder',                    // ID
       'Base Location',                         // Title
       array( $this, 'input_select_callback' ), // Callback
       'wpscss_options',                        // Page
-      'wpscss_paths_section',                // Section
+      'wpscss_paths_section',                  // Section
       array(                                   // args
         'name' => 'base_compiling_folder',
         'type' => apply_filters( 'wp_scss_base_compiling_modes',
-          array(
-            get_template_directory()  => 'Parent theme', // Won't display if no parent theme as it would have duplicate keys in array
-            get_stylesheet_directory()  => (get_stylesheet_directory() === get_template_directory() ? 'Current theme' : 'Child theme'),
-            wp_get_upload_dir()['basedir'] => 'Uploads directory',
-            WPSCSS_PLUGIN_DIR => 'WP-SCSS Plugin',
-          )
+        $base_folder_options
+          // array(
+          //   get_template_directory()  => 'Parent theme', // Won't display if no parent theme as it would have duplicate keys in array
+          //   get_stylesheet_directory()  => (get_stylesheet_directory() === get_template_directory() ? 'Current theme' : 'Child theme'),
+          //   wp_get_upload_dir()['basedir'] => 'Uploads directory',
+          //   WPSCSS_PLUGIN_DIR => 'WP-SCSS Plugin',
+          // )
         )
       )
     );
+
+    add_settings_field(
+      'Use Absolute Path',                       // ID
+      'Use Absolute Path',                       // Title
+      array( $this, 'input_checkbox_callback' ), // Callback
+      'wpscss_options',                          // Page
+      'wpscss_paths_section',                    // Section
+      array(                                     // args
+        'name' => 'use_absolute_paths'
+      )
+    );
+
 
     add_settings_field(
       'wpscss_scss_dir',                     // ID

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -131,7 +131,7 @@ function wpscss_plugin_db_cleanup($option_values){
  */
 
 // Allow current WP to keep these values don't store to db
-function get_base_dir_from_name($name){
+function get_base_dir_from_name($name_or_old_path){
   $possible_directories = array(
     'Parent Theme'      => get_template_directory(), // Won't display if no parent theme as it would have duplicate keys in array
     'Current Theme'     => get_stylesheet_directory(),
@@ -139,9 +139,17 @@ function get_base_dir_from_name($name){
     'Uploads Directory' => wp_get_upload_dir()['basedir'],
     'WP-SCSS Plugin'    => WPSCSS_PLUGIN_DIR,
   );
-  return $possible_directories[$name];
+  $directory_path = $possible_directories[$name_or_old_path];
+  if($directory_path){
+    return $directory_path;
+  }else{
+    return $name_or_old_path;
+  }
 }
+
 $wpscss_options = get_option( 'wpscss_options' );
+$test = get_base_dir_from_name($wpscss_options['base_compiling_folder']);
+echo($test);
 // $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
 $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? $wpscss_options['base_compiling_folder'] : get_stylesheet_directory();
 $scss_dir_setting = isset($wpscss_options['scss_dir']) ? $wpscss_options['scss_dir'] : '';

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -139,18 +139,19 @@ function get_base_dir_from_name($name_or_old_path){
     'Uploads Directory' => wp_get_upload_dir()['basedir'],
     'WP-SCSS Plugin'    => WPSCSS_PLUGIN_DIR,
   );
-  $directory_path = $possible_directories[$name_or_old_path];
-  echo($name_or_old_path);
-  echo($directory_path);
-  if($directory_path){
+  if(array_key_exists($name_or_old_path, $possible_directories)){
     return $directory_path;
   }else{
+    add_action('admin_notices', function(){
+      echo '<div class="notice notice-info">
+        <p><strong>WP-SCSS:</strong> <a href="' . get_bloginfo('wpurl') . '/wp-admin/admin.php?page=wpscss_options">Please save your settings</a> to make use of the new dynamic Base Location.</p>
+      </div>';
+    });
     return $name_or_old_path;
   }
 }
 
 $wpscss_options = get_option( 'wpscss_options' );
-$test = get_base_dir_from_name($wpscss_options['base_compiling_folder']);
 $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
 $scss_dir_setting = isset($wpscss_options['scss_dir']) ? $wpscss_options['scss_dir'] : '';
 $css_dir_setting = isset($wpscss_options['css_dir']) ? $wpscss_options['css_dir'] : '';
@@ -158,7 +159,7 @@ $css_dir_setting = isset($wpscss_options['css_dir']) ? $wpscss_options['css_dir'
 // Checks if directories are not yet defined
 if( $scss_dir_setting == false || $css_dir_setting == false ) {
   function wpscss_settings_error() {
-    echo '<div class="error">
+    echo '<div class="notice notice-error">
       <p><strong>WP-SCSS</strong> requires both directories be specified. <a href="' . get_bloginfo('wpurl') . '/wp-admin/admin.php?page=wpscss_options">Please update your settings.</a></p>
       </div>';
   }
@@ -168,7 +169,7 @@ if( $scss_dir_setting == false || $css_dir_setting == false ) {
   // Checks if SCSS directory exists
 } elseif ( !is_dir($base_compiling_folder . $scss_dir_setting) ) {
   add_action('admin_notices', function() use ($base_compiling_folder, $scss_dir_setting){
-    echo '<div class="error">
+    echo '<div class="notice notice-error">
       <p><strong>WP-SCSS:</strong> The SCSS directory does not exist (' . $base_compiling_folder . $scss_dir_setting . '). Please create the directory or <a href="' . get_bloginfo('wpurl') . '/wp-admin/admin.php?page=wpscss_options">update your settings.</a></p>
       </div>';
   });
@@ -177,7 +178,7 @@ if( $scss_dir_setting == false || $css_dir_setting == false ) {
   // Checks if CSS directory exists
 } elseif ( !is_dir($base_compiling_folder . $css_dir_setting) ) {
   add_action('admin_notices', function() use ($base_compiling_folder, $css_dir_setting){
-    echo '<div class="error">
+    echo '<div class="notice notice-error">
       <p><strong>WP-SCSS:</strong> The CSS directory does not exist (' . $base_compiling_folder . $css_dir_setting . '). Please create the directory or <a href="' . get_bloginfo('wpurl') . '/wp-admin/admin.php?page=wpscss_options">update your settings.</a></p>
       </div>';
   });

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -130,7 +130,19 @@ function wpscss_plugin_db_cleanup($option_values){
  * Assign settings via settings array to pass to object
  */
 
+// Allow current WP to keep these values don't store to db
+function get_base_dir_from_name($name){
+  $possible_directories = array(
+    'Parent Theme'      => get_template_directory(), // Won't display if no parent theme as it would have duplicate keys in array
+    'Current Theme'     => get_stylesheet_directory(),
+    'Child Theme'       => get_stylesheet_directory(),
+    'Uploads Directory' => wp_get_upload_dir()['basedir'],
+    'WP-SCSS Plugin'    => WPSCSS_PLUGIN_DIR,
+  );
+  return $possible_directories[$name];
+}
 $wpscss_options = get_option( 'wpscss_options' );
+// $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
 $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? $wpscss_options['base_compiling_folder'] : get_stylesheet_directory();
 $scss_dir_setting = isset($wpscss_options['scss_dir']) ? $wpscss_options['scss_dir'] : '';
 $css_dir_setting = isset($wpscss_options['css_dir']) ? $wpscss_options['css_dir'] : '';

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -140,6 +140,8 @@ function get_base_dir_from_name($name_or_old_path){
     'WP-SCSS Plugin'    => WPSCSS_PLUGIN_DIR,
   );
   $directory_path = $possible_directories[$name_or_old_path];
+  echo($name_or_old_path);
+  echo($directory_path);
   if($directory_path){
     return $directory_path;
   }else{
@@ -149,9 +151,7 @@ function get_base_dir_from_name($name_or_old_path){
 
 $wpscss_options = get_option( 'wpscss_options' );
 $test = get_base_dir_from_name($wpscss_options['base_compiling_folder']);
-echo($test);
-// $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
-$base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? $wpscss_options['base_compiling_folder'] : get_stylesheet_directory();
+$base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
 $scss_dir_setting = isset($wpscss_options['scss_dir']) ? $wpscss_options['scss_dir'] : '';
 $css_dir_setting = isset($wpscss_options['css_dir']) ? $wpscss_options['css_dir'] : '';
 


### PR DESCRIPTION
Fixes #196, where database contained information about WP install location. This caused issues when migrating to another server.

Possible additional work: 
- Auto update values instead of admin callout to save.
- Keep order to Base Location dropdown