### PR TITLE
Make cache directory configurable like other dirs

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -17,14 +17,13 @@ class Wp_Scss {
    *
    * @var array compile_errors - catches errors from compile
    */
-  public function __construct ($scss_dir, $css_dir, $compile_method, $sourcemaps) {
+  public function __construct ($scss_dir, $css_dir, $cache_dir, $compile_method, $sourcemaps) {
 
     $this->scss_dir         = $scss_dir;
     $this->css_dir          = $css_dir;
+    $this->cache            = $cache_dir;
     $this->compile_errors   = array();
     $this->scssc            = new Compiler();
-
-    $this->cache = WPSCSS_PLUGIN_DIR . '/cache/';
 
     $this->scssc->setOutputStyle( $compile_method );
     $this->scssc->setImportPaths( $this->scss_dir );

--- a/options.php
+++ b/options.php
@@ -136,6 +136,17 @@ class Wp_Scss_Settings {
       )
     );
 
+    add_settings_field(
+      'wpscss_cache_dir',                     // ID
+      'Cache Location',                       // Title
+      array( $this, 'input_text_callback' ),  // Callback
+      'wpscss_options',                       // Page
+      'wpscss_paths_section',                 // Section
+      array(                                  // args
+        'name' => 'cache_dir',
+      )
+    );
+
     // Compiling Options
     add_settings_section(
       'wpscss_compile_section',             // ID

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -164,6 +164,7 @@ $wpscss_options = get_option( 'wpscss_options' );
 $base_compiling_folder = isset($wpscss_options['base_compiling_folder']) ? get_base_dir_from_name($wpscss_options['base_compiling_folder']) : get_stylesheet_directory();
 $scss_dir_setting = isset($wpscss_options['scss_dir']) ? $wpscss_options['scss_dir'] : '';
 $css_dir_setting = isset($wpscss_options['css_dir']) ? $wpscss_options['css_dir'] : '';
+$cache_dir_setting = isset($wpscss_options['cache_dir']) ? $wpscss_options['cache_dir'] : WPSCSS_PLUGIN_DIR . '/cache/';
 
 // Checks if directories are not yet defined
 if( $scss_dir_setting == false || $css_dir_setting == false ) {
@@ -198,6 +199,7 @@ if( $scss_dir_setting == false || $css_dir_setting == false ) {
 $wpscss_settings = array(
   'scss_dir'         => $base_compiling_folder . $scss_dir_setting,
   'css_dir'          => $base_compiling_folder . $css_dir_setting,
+  'cache_dir'        => $base_compiling_folder . $cache_dir_setting,
   'compiling'        => isset($wpscss_options['compiling_options']) ? $wpscss_options['compiling_options'] : 'compressed',
   'always_recompile' => isset($wpscss_options['always_recompile'])  ? $wpscss_options['always_recompile']  : false,
   'errors'           => isset($wpscss_options['errors'])            ? $wpscss_options['errors']            : 'show',
@@ -217,6 +219,7 @@ global $wpscss_compiler;
 $wpscss_compiler = new Wp_Scss(
   $wpscss_settings['scss_dir'],
   $wpscss_settings['css_dir'],
+  $wpscss_settings['cache_dir'],
   $wpscss_settings['compiling'],
   $wpscss_settings['sourcemaps']
 );


### PR DESCRIPTION
## Why are these changes being introduced:

* Some environments deny plugins the ability to create and maintain a cache internally, but other locations (like the uploads directory) may be okay.
* The plugin already allows the ability to configure the scss and css folders, so perhaps the cache directory could be treated similarly.

## Relevant ticket(s):

* https://github.com/ConnectThink/WP-SCSS/issues/197

## How does this address that need:

* This attempts to handle the cache directory in a similar fashion to the scss and css directory, leveraging the work already done to move those locations according to user preferences.
* I've tested this change by deploying this update within a Pantheon application, and it appears to work correctly - but I'm not sure how to confirm whether the fix works more repeatedly elsewhere.
 
## Document any side effects to this change:

* The Wp_Scss class uses `cache` instead of `cache_dir`, while the other folders are named `scss_dir` and `css_dir`. I've opted to leave these names intact to try and make the smallest possible change, but this may be a mistake.