### PR TITLE
Fix: Avoid usage of dynamic property for cache_file

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -117,10 +117,10 @@ class Wp_Scss {
 
     if (count($this->compile_errors) < 1) {
       if  ( is_writable($this->css_dir) ) {
-        foreach (new DirectoryIterator($this->cache) as $this->cache_file) {
-          if ( pathinfo($this->cache_file->getFilename(), PATHINFO_EXTENSION) == 'css') {
-            file_put_contents($this->css_dir . $this->cache_file, file_get_contents($this->cache . $this->cache_file));
-            unlink($this->cache . $this->cache_file->getFilename()); // Delete file on successful write
+        foreach (new DirectoryIterator($this->cache) as $cache_file) {
+          if (pathinfo($cache_file->getFilename(), PATHINFO_EXTENSION) == 'css') {
+            file_put_contents($this->css_dir . $cache_file, file_get_contents($this->cache . $cache_file));
+            unlink($this->cache . $cache_file->getFilename()); // Delete file on successful write
           }
         }
       } else {


### PR DESCRIPTION
- Replaced `$this->cache_file` with a local variable `$cache_file` in the loop  
- Fixed PHP 8.2 deprecation warning related to dynamic properties