### PR TITLE
feat: Deploy to Wordpress SVN via GitHub

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,10 @@
+/.wordpress-org
+/.github
+/tests
+/node_modules
+/composer.json
+/composer.lock
+/phpunit.xml.dist
+/.git
+/.gitignore
+/.gitattributes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@v2
         with:
-          dry-run: ${{ inputs.dry-run }}
+          dry-run: ${{ inputs['dry-run'] == 'true' }}
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to WordPress.org
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Run as dry-run (no changes will be pushed)'
+        required: false
+        default: 'false'
+
+jobs:
+  deploy:
+    name: WordPress Plugin Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@v2
+        with:
+          dry-run: ${{ inputs.dry-run }}
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,137 @@
+# WordPress Plugin Deployment Guide
+
+This guide covers deploying WP-SCSS to the WordPress.org plugin repository using GitHub Actions.
+
+## Prerequisites
+
+### Repository Secrets
+Set up these secrets in your GitHub repository (Settings → Secrets and variables → Actions):
+
+1. **SVN_USERNAME**: Your WordPress.org username
+2. **SVN_PASSWORD**: Your WordPress.org password
+
+### WordPress.org Plugin Setup
+- Ensure your plugin is approved and listed on WordPress.org
+- Verify you have commit access to the plugin's SVN repository
+
+## Deployment Methods
+
+### 1. Tag-Based Deployment (Recommended)
+Automatically deploys when you create a new tag:
+
+```bash
+# Create and push a new tag
+git tag 4.0.4
+git push origin 4.0.4
+```
+
+### 2. Manual Deployment
+Use the workflow dispatch option:
+
+1. Go to Actions → Deploy to WordPress.org
+2. Click "Run workflow"
+3. Optionally enable "dry-run" to test without deploying
+
+## Pre-Deployment Checklist
+
+### Version Consistency
+Ensure these files have matching version numbers:
+- [ ] `wp-scss.php` (Plugin header and `WPSCSS_VERSION_NUM`)
+- [ ] `readme.txt` (Stable tag)
+
+### Code Quality
+- [ ] Test plugin functionality locally
+- [ ] Verify no PHP errors or warnings
+- [ ] Check WordPress coding standards compliance
+
+### Documentation
+- [ ] Update `readme.txt` changelog
+- [ ] Update `README.md` if needed
+- [ ] Document any breaking changes
+
+## Deployment Process
+
+1. **Update Version Numbers**
+   ```bash
+   # Update version in wp-scss.php (line 6 and line 47)
+   # Update stable tag in readme.txt (line 8)
+   ```
+
+2. **Commit Changes**
+   ```bash
+   git add .
+   git commit -m "Version bump to X.X.X"
+   git push origin master
+   ```
+
+3. **Create Release Tag**
+   ```bash
+   git tag X.X.X
+   git push origin X.X.X
+   ```
+
+4. **Monitor Deployment**
+   - GitHub Actions will automatically trigger
+   - Check the Actions tab for deployment status
+   - Verify the plugin updates on WordPress.org
+
+## Troubleshooting
+
+### Common Issues
+
+**Authentication Failed**
+- Verify SVN_USERNAME and SVN_PASSWORD secrets
+- Check WordPress.org account permissions
+
+**Version Conflicts**
+- Ensure tag version matches plugin file versions
+- Check that the tag doesn't already exist
+
+**Build Failures**
+- Review GitHub Actions logs
+- Test deployment with dry-run first
+
+### Manual SVN Deployment (Fallback)
+
+If GitHub Actions fails, deploy manually:
+
+```bash
+# Clone SVN repository
+svn co https://plugins.svn.wordpress.org/wp-scss wp-scss-svn
+
+# Copy files to trunk
+cp -r wp-scss/* wp-scss-svn/trunk/
+
+# Create tag directory
+svn cp trunk tags/X.X.X
+
+# Commit changes
+svn ci -m "Version X.X.X"
+```
+
+## Workflow Configuration
+
+The deployment workflow (`.github/workflows/deploy.yml`) includes:
+- Automatic deployment on tag push
+- Manual dispatch with dry-run option
+- Uses 10up/action-wordpress-plugin-deploy@v2
+- Runs on Ubuntu latest
+
+## Best Practices
+
+1. **Test First**: Use dry-run mode for new deployments
+2. **Semantic Versioning**: Follow semver (major.minor.patch)
+3. **Changelog**: Always update readme.txt changelog
+4. **Backup**: Keep local backups before major releases
+5. **Monitor**: Watch WordPress.org for user feedback post-deployment
+
+## Release Checklist
+
+- [ ] Version numbers updated consistently
+- [ ] Code tested locally
+- [ ] Changelog updated in readme.txt
+- [ ] Breaking changes documented
+- [ ] Git tag created and pushed
+- [ ] GitHub Actions deployment successful
+- [ ] WordPress.org plugin page updated
+- [ ] User notifications sent (if needed)

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,21 +2,10 @@
 
 This guide covers deploying WP-SCSS to the WordPress.org plugin repository using GitHub Actions.
 
-## Prerequisites
-
-### Repository Secrets
-Set up these secrets in your GitHub repository (Settings → Secrets and variables → Actions):
-
-1. **SVN_USERNAME**: Your WordPress.org username
-2. **SVN_PASSWORD**: Your WordPress.org password
-
-### WordPress.org Plugin Setup
-- Ensure your plugin is approved and listed on WordPress.org
-- Verify you have commit access to the plugin's SVN repository
-
 ## Deployment Methods
 
 ### 1. Tag-Based Deployment (Recommended)
+
 Automatically deploys when you create a new tag:
 
 ```bash
@@ -26,6 +15,7 @@ git push origin 4.0.4
 ```
 
 ### 2. Manual Deployment
+
 Use the workflow dispatch option:
 
 1. Go to Actions → Deploy to WordPress.org
@@ -35,16 +25,20 @@ Use the workflow dispatch option:
 ## Pre-Deployment Checklist
 
 ### Version Consistency
+
 Ensure these files have matching version numbers:
+
 - [ ] `wp-scss.php` (Plugin header and `WPSCSS_VERSION_NUM`)
 - [ ] `readme.txt` (Stable tag)
 
 ### Code Quality
+
 - [ ] Test plugin functionality locally
 - [ ] Verify no PHP errors or warnings
 - [ ] Check WordPress coding standards compliance
 
 ### Documentation
+
 - [ ] Update `readme.txt` changelog
 - [ ] Update `README.md` if needed
 - [ ] Document any breaking changes
@@ -52,12 +46,14 @@ Ensure these files have matching version numbers:
 ## Deployment Process
 
 1. **Update Version Numbers**
+
    ```bash
    # Update version in wp-scss.php (line 6 and line 47)
    # Update stable tag in readme.txt (line 8)
    ```
 
 2. **Commit Changes**
+
    ```bash
    git add .
    git commit -m "Version bump to X.X.X"
@@ -65,6 +61,7 @@ Ensure these files have matching version numbers:
    ```
 
 3. **Create Release Tag**
+
    ```bash
    git tag X.X.X
    git push origin X.X.X
@@ -80,14 +77,17 @@ Ensure these files have matching version numbers:
 ### Common Issues
 
 **Authentication Failed**
+
 - Verify SVN_USERNAME and SVN_PASSWORD secrets
 - Check WordPress.org account permissions
 
 **Version Conflicts**
+
 - Ensure tag version matches plugin file versions
 - Check that the tag doesn't already exist
 
 **Build Failures**
+
 - Review GitHub Actions logs
 - Test deployment with dry-run first
 
@@ -112,6 +112,7 @@ svn ci -m "Version X.X.X"
 ## Workflow Configuration
 
 The deployment workflow (`.github/workflows/deploy.yml`) includes:
+
 - Automatic deployment on tag push
 - Manual dispatch with dry-run option
 - Uses 10up/action-wordpress-plugin-deploy@v2

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -48,8 +48,8 @@ Ensure these files have matching version numbers:
 1. **Update Version Numbers**
 
    ```bash
-   # Update version in wp-scss.php (line 6 and line 47)
-   # Update stable tag in readme.txt (line 8)
+   # Update version in wp-scss.php (plugin header and `WPSCSS_VERSION_NUM` constant)
+   # Update stable tag in readme.txt (under "Stable tag" in the file header)
    ```
 
 2. **Commit Changes**


### PR DESCRIPTION
SVN is such a headache that it stops me from working on this project and wanting to even do minor fixes. Having the option to deploy via GitHub is a HUGE win