### PR TITLE
Version 4.0.4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
       dry-run:
         description: 'Run as dry-run (no changes will be pushed)'
         required: false
-        default: 'false'
+        default: 'true'
 
 jobs:
   deploy:

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/ConnectThink/WP-SCSS
 Requires at least: 3.0.1
 Tested up to: 6.4.2
 Requires PHP: 7.2
-Stable tag: 4.0.3
+Stable tag: 4.0.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl.html
 
@@ -79,6 +79,12 @@ If you are having issues with the plugin, create an issue on [github](https://gi
 
 
 == Changelog ==
+
+= 4.0.4 =
+  - Fix: Avoid usage of dynamic property for cache_file. Thanks to [FreddyFY](https://github.com/ConnectThink/WP-SCSS/pull/256)
+  - Actually update PHP deprecated notices. Missed files in early version bump.
+  - Add Github Actions deploy script, because dealing with SVN is not fun. [#260](https://github.com/ConnectThink/WP-SCSS/pull/260)
+  - Add Claude init files, because it knows PHP better than I do. [#258](https://github.com/ConnectThink/WP-SCSS/pull/258)
 
 = 4.0.3 =
   - Remove PHP Deprecated notices

--- a/wp-scss.php
+++ b/wp-scss.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP-SCSS
  * Plugin URI: https://github.com/ConnectThink/WP-SCSS
  * Description: Compiles scss files live on WordPress.
- * Version: 4.0.3
+ * Version: 4.0.4
  * Author: Connect Think
  * Author URI: http://connectthink.com
  * License: GPLv3
@@ -44,7 +44,7 @@ if (!defined('WPSCSS_VERSION_KEY'))
   define('WPSCSS_VERSION_KEY', 'wpscss_version');
 
 if (!defined('WPSCSS_VERSION_NUM'))
-  define('WPSCSS_VERSION_NUM', '4.0.3');
+  define('WPSCSS_VERSION_NUM', '4.0.4');
 
 // Add version to options table
 if ( get_option( WPSCSS_VERSION_KEY ) !== false ) {


### PR DESCRIPTION
  - Fix: Avoid usage of dynamic property for cache_file. Thanks to
  - Actually update PHP deprecated notices. Missed files in early version bump.
  - Add Github Actions deploy script, because dealing with SVN is not fun.
  - Add Claude init files, because it knows PHP better than I do.