### PR TITLE
Improve SCSS cache directory creation and error handling

### DIFF
--- a/class/class-wp-scss.php
+++ b/class/class-wp-scss.php
@@ -151,7 +151,7 @@ class Wp_Scss {
   private function compiler($in, $out) {
 
     if (!file_exists($this->cache)) {
-      mkdir($this->cache, 0644);
+      wp_mkdir_p($this->cache);
     }
     if (is_writable($this->cache)) {
       try {
@@ -176,9 +176,12 @@ class Wp_Scss {
         array_push($this->compile_errors, $errors);
       }
     } else {
+      $message = !file_exists($this->cache)
+        ? "File Permission Error, unable to create the cache directory. Please manually create: " . $this->cache
+        : "File Permission Error, permission denied. Please make the cache directory writable.";
       $errors = array (
         'file' => $this->cache,
-        'message' => "File Permission Error, permission denied. Please make the cache directory writable."
+        'message' => $message
       );
       array_push($this->compile_errors, $errors);
     }


### PR DESCRIPTION
## Summary
This PR improves the reliability and user experience of the SCSS compiler's cache directory handling by using WordPress's built-in directory creation function and providing more informative error messages.

## Key Changes
- **Replace `mkdir()` with `wp_mkdir_p()`**: Changed from the basic PHP `mkdir()` function to WordPress's `wp_mkdir_p()` function, which creates directories recursively and respects WordPress conventions
- **Enhanced error messaging**: Updated error messages to distinguish between two failure scenarios:
  - When the cache directory doesn't exist and cannot be created
  - When the cache directory exists but lacks write permissions
  - This provides clearer guidance to users on how to resolve the issue

## Implementation Details
- The `wp_mkdir_p()` function is more robust than `mkdir()` as it creates parent directories if needed and handles edge cases better
- The error message now conditionally displays based on whether the cache directory exists, helping users understand the root cause of the permission error
- The cache directory path is included in the error message to help users locate and manually create/fix the directory if needed

https://claude.ai/code/session_01KsZF2sudPbLYyzoWNSjBAG